### PR TITLE
Fix building with dockerfiles

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -156,6 +156,8 @@ RUN cd ${CURL_VERSION} && \
 {{#firefox}}
                 --with-nss=/build/${NSS_VERSION}/dist/Release \
                 --with-nss-deprecated \
+                --without-zstd \
+                --enable-ech \
                 CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
 {{/firefox}}
 {{#chrome}}
@@ -196,6 +198,8 @@ RUN cd ${CURL_VERSION} && \
 {{#firefox}}
                 --with-nss=/build/${NSS_VERSION}/dist/Release \
                 --with-nss-deprecated \
+                --without-zstd \
+                --enable-ech \
                 CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
 {{/firefox}}
 {{#chrome}}

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -95,6 +95,8 @@ RUN cd ${CURL_VERSION} && \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-openssl=/build/boringssl/build \
+                --without-zstd \
+                --enable-ech \
                 LIBS="-pthread" \
                 CFLAGS="-I/build/boringssl/build" \
                 USE_CURL_SSLKEYLOGFILE=true && \
@@ -122,6 +124,8 @@ RUN cd ${CURL_VERSION} && \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-openssl=/build/boringssl/build \
+                --without-zstd \
+                --enable-ech \
                 LIBS="-pthread" \
                 CFLAGS="-I/build/boringssl/build" \
                 USE_CURL_SSLKEYLOGFILE=true && \

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -88,6 +88,8 @@ RUN cd ${CURL_VERSION} && \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-openssl=/build/boringssl/build \
+                --without-zstd \
+                --enable-ech \
                 LIBS="-pthread" \
                 CFLAGS="-I/build/boringssl/build" \
                 USE_CURL_SSLKEYLOGFILE=true && \
@@ -115,6 +117,8 @@ RUN cd ${CURL_VERSION} && \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-openssl=/build/boringssl/build \
+                --without-zstd \
+                --enable-ech \
                 LIBS="-pthread" \
                 CFLAGS="-I/build/boringssl/build" \
                 USE_CURL_SSLKEYLOGFILE=true && \

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -90,6 +90,8 @@ RUN cd ${CURL_VERSION} && \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-nss=/build/${NSS_VERSION}/dist/Release \
                 --with-nss-deprecated \
+                --without-zstd \
+                --enable-ech \
                 CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
                 USE_CURL_SSLKEYLOGFILE=true && \
     make && make install
@@ -117,6 +119,8 @@ RUN cd ${CURL_VERSION} && \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-nss=/build/${NSS_VERSION}/dist/Release \
                 --with-nss-deprecated \
+                --without-zstd \
+                --enable-ech \
                 CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
                 USE_CURL_SSLKEYLOGFILE=true && \
     make clean && make && make install

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -79,6 +79,8 @@ RUN cd ${CURL_VERSION} && \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-nss=/build/${NSS_VERSION}/dist/Release \
                 --with-nss-deprecated \
+                --without-zstd \
+                --enable-ech \
                 CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
                 USE_CURL_SSLKEYLOGFILE=true && \
     make && make install
@@ -106,6 +108,8 @@ RUN cd ${CURL_VERSION} && \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-nss=/build/${NSS_VERSION}/dist/Release \
                 --with-nss-deprecated \
+                --without-zstd \
+                --enable-ech \
                 CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
                 USE_CURL_SSLKEYLOGFILE=true && \
     make clean && make && make install


### PR DESCRIPTION
The Dockerfiles didn't get their libcurl options updated.

Test that they work with `sudo build -t curl-impersonate-chrome chrome/` and `sudo docker run --rm THE_DOCKER_IMAGE_ID_IT_SPITS_OUT_AT_THE_END curl_chrome119 -L crouton.net`

I have no idea how to install mustache on arch to get the generate_dockerfiles.sh to work, but it makes sense that that the Dockerfile.template works.