### PR TITLE
Fix arm libcurl builds

### DIFF
--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -60,7 +60,7 @@ jobs:
             ENV HOME=$HOME
             ENV CC=/opt/rh/devtoolset-10/root/usr/bin/gcc
             ENV CXX=/opt/rh/devtoolset-10/root/usr/bin/g++
-            ENV LD=/opt/rh/devtoolset-10/root/usr/bin/ld
+            ENV LD=/usr/bin/ld
             RUN yum install -y libcurl-devel
             RUN python3.10 -m pip install ninja cmake gyp-next --extra-index-url https://bjia56.github.io/armv7l-wheels/
             RUN rm -rf /usr/local/go && \

--- a/Makefile.in
+++ b/Makefile.in
@@ -412,7 +412,9 @@ $(CURL_VERSION)/.chrome: $(chrome_libs)	$(CURL_VERSION).tar.xz $(CURL_VERSION)/.
 	  config_flags="$$config_flags --enable-ech"; \
 	  config_flags="$$config_flags USE_CURL_SSLKEYLOGFILE=true"; \
 	  if test "$(static_build)" = "yes"; then \
-	    config_flags="$$config_flags --enable-static --disable-shared";
+	    config_flags="$$config_flags --enable-static --disable-shared"; \
+	  else \
+	    config_flags="$$config_flags --enable-static --enable-shared"; \
 	  fi; \
 	  if test -n "$(host_alias)"; then \
 	    config_flags="$$config_flags --host=$(host_alias)"; \

--- a/Makefile.in
+++ b/Makefile.in
@@ -412,9 +412,7 @@ $(CURL_VERSION)/.chrome: $(chrome_libs)	$(CURL_VERSION).tar.xz $(CURL_VERSION)/.
 	  config_flags="$$config_flags --enable-ech"; \
 	  config_flags="$$config_flags USE_CURL_SSLKEYLOGFILE=true"; \
 	  if test "$(static_build)" = "yes"; then \
-	    config_flags="$$config_flags --enable-static --disable-shared"; \
-	  else \
-	    config_flags="$$config_flags --enable-static --enable-shared"; \
+	    config_flags="$$config_flags --enable-static --disable-shared";
 	  fi; \
 	  if test -n "$(host_alias)"; then \
 	    config_flags="$$config_flags --host=$(host_alias)"; \


### PR DESCRIPTION
Makes progress towards #32 by fixing libcurl builds for arm, hopefully unblocking curl_cffi development. Static curl builds are still broken after this, I will keep looking at those.

Once I get devtoolset-10-binutils compiled for arm, I'll open another PR to switch back to the devtoolset ld. 