### PR TITLE
remove zlib build from macos

### DIFF
--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -316,17 +316,6 @@ jobs:
         run: |
           pip3 install -r tests/requirements.txt
 
-      - name: Build zlib
-        run: |
-          curl -LO https://zlib.net/zlib-1.3.tar.gz
-          tar xf zlib-1.3.tar.gz
-          cd zlib-1.3
-          CHOST=${{ matrix.host }} ./configure --prefix=${{ runner.temp }}/zlib
-          make
-          make install
-          # Make sure curl will link with libz.so.1 and not libz.so
-          rm -f ${{ runner.temp }}/zlib/lib/libz.so
-
       - name: Run configure script
         if: matrix.arch == 'x86_64'
         run: |


### PR DESCRIPTION
This build doesn't seem to be doing anything anymore. Furthermore, zlib 1.3.1 was just released and the 1.3 source download link is now broken. 