### PR TITLE
Arm fixes + upload archives for each build

### DIFF
--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -167,13 +167,18 @@ jobs:
           python_bin=$(which python3)
           sudo $python_bin -m pytest . --log-cli-level DEBUG --install-dir ${{ runner.temp }}/install --capture-interface ${{ matrix.capture_interface }}
 
-       # Upload pre-compiled binaries to GitHub releases page.
+       # Upload pre-compiled binaries to GitHub releases page and Github actions archives.
       - name: Create tar release files for libcurl-impersonate
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
             cd ${{ runner.temp }}/install/lib
             tar -c -z -f ${{ runner.temp }}/libcurl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz libcurl-impersonate*
             echo "release_file_lib=${{ runner.temp }}/libcurl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: libcurl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz
+          path: ${{ runner.temp }}/libcurl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz
 
       - name: Clean build
         if: startsWith(github.ref, 'refs/tags/')
@@ -220,11 +225,16 @@ jobs:
             make chrome-install-strip
 
       - name: Create tar release files for curl-impersonate
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           cd ${{ runner.temp }}/install/bin
           tar -c -z -f ${{ runner.temp }}/curl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz curl-impersonate-chrome curl_*
           echo "release_file_bin=${{ runner.temp }}/curl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: curl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz
+          path: ${{ runner.temp }}/curl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz
 
       - name: Upload release files
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -170,18 +170,21 @@ jobs:
        # Upload pre-compiled binaries to GitHub releases page and Github actions archives.
       - name: Create tar release files for libcurl-impersonate
         run: |
-            cd ${{ runner.temp }}/install/lib
+          cd ${{ runner.temp }}/install/lib
+          if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
             tar -c -z -f ${{ runner.temp }}/libcurl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz libcurl-impersonate*
-            echo "release_file_lib=${{ runner.temp }}/libcurl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz" >> $GITHUB_ENV
+          else
+            tar -c -z -f ${{ runner.temp }}/libcurl-impersonate.${{ matrix.host }}.tar.gz libcurl-impersonate*
+          fi
+          echo "release_file_lib=${{ runner.temp }}/libcurl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz" >> $GITHUB_ENV
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: libcurl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz
-          path: ${{ runner.temp }}/libcurl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz
+          name: libcurl-impersonate.${{ matrix.host }}.tar.gz
+          path: ${{ runner.temp }}/libcurl-impersonate*.tar.gz
 
       - name: Clean build
-        if: startsWith(github.ref, 'refs/tags/')
         uses: addnab/docker-run-action@v3
         with:
           image: curl-impersonate-builder
@@ -197,7 +200,6 @@ jobs:
 
        # Recompile curl-impersonate statically when doing a release.
       - name: Reconfigure statically
-        if: startsWith(github.ref, 'refs/tags/') && matrix.arch == 'x86_64'
         uses: addnab/docker-run-action@v3
         with:
           image: curl-impersonate-builder
@@ -210,7 +212,6 @@ jobs:
             ./configure --prefix=${{ runner.temp }}/install --enable-static
 
       - name: Rebuild statically
-        if: startsWith(github.ref, 'refs/tags/')
         uses: addnab/docker-run-action@v3
         with:
           image: curl-impersonate-builder
@@ -227,14 +228,18 @@ jobs:
       - name: Create tar release files for curl-impersonate
         run: |
           cd ${{ runner.temp }}/install/bin
-          tar -c -z -f ${{ runner.temp }}/curl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz curl-impersonate-chrome curl_*
+          if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
+            tar -c -z -f ${{ runner.temp }}/curl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz curl-impersonate-chrome curl_*
+          else
+            tar -c -z -f ${{ runner.temp }}/curl-impersonate.${{ matrix.host }}.tar.gz curl-impersonate-chrome curl_*
+          fi
           echo "release_file_bin=${{ runner.temp }}/curl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz" >> $GITHUB_ENV
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: curl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz
-          path: ${{ runner.temp }}/curl-impersonate-${{ github.ref_name }}.${{ matrix.host }}.tar.gz
+          name: curl-impersonate.${{ matrix.host }}.tar.gz
+          path: ${{ runner.temp }}/curl-impersonate*.tar.gz
 
       - name: Upload release files
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The underlying issue with the releases is likely due to this line incorrectly skipping the step for non-x86_64: https://github.com/yifeikong/curl-impersonate/blob/7a708de5e1b50690e57d651e398143dd7101f67c/.github/workflows/build-and-test-make.yml#L195

I added archiving the artifacts from each run so it would be easier to download and inspect without having to go through the tag and release process. If not wanted, I can remove it.

Resolves #32 