### PR TITLE
Change example URL in README

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,13 +48,13 @@ This will install curl-impersonate, libcurl-impersonate and the wrapper scripts 
 After installation you can run the wrapper scripts, e.g.:
 
 ```sh
-curl_chrome119 https://www.wikipedia.org
+curl_chrome119 https://www.example.com
 ```
 
 or run directly with you own flags:
 
 ```sh
-curl-impersonate https://www.wikipedia.org
+curl-impersonate https://www.example.com
 ```
 
 ### Red Hat based (CentOS/Fedora/Amazon Linux)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ You can also use the following docker images:
 
 For each supported browser there is a wrapper script that launches `curl-impersonate` with all the needed headers and flags. For example:
 
-    curl_chrome123 https://www.wikipedia.org
+    curl_chrome123 https://www.example.com/
 
 You can add command line flags and they will be passed on to curl. However, some flags
 change curl's TLS signature which may cause it to be detected.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ You can also use the following docker images:
 
 For each supported browser there is a wrapper script that launches `curl-impersonate` with all the needed headers and flags. For example:
 
-    curl_chrome123 https://www.example.com/
+    curl_chrome123 https://www.example.com
 
 You can add command line flags and they will be passed on to curl. However, some flags
 change curl's TLS signature which may cause it to be detected.

--- a/docs/02_install.md
+++ b/docs/02_install.md
@@ -13,7 +13,7 @@ The pre-compiled binaries contain `libcurl-impersonate` and a statically compile
 
 The pre-compiled Linux binaries are built for Ubuntu systems. On other distributions if you have errors with certificate verification you may have to tell curl where to find the CA certificates. For example:
 
-    curl_chrome123 https://www.wikipedia.org --cacert /etc/ssl/certs/ca-bundle.crt
+    curl_chrome123 https://www.example.com --cacert /etc/ssl/certs/ca-bundle.crt
 
 Also make sure to read [Notes on Dependencies](#notes-on-dependencies).
 
@@ -31,7 +31,7 @@ Docker images based on Alpine Linux and Debian with `curl-impersonate` compiled 
 ```bash
 # Chrome version, Alpine Linux
 docker pull lwthiker/curl-impersonate:0.5-chrome
-docker run --rm lwthiker/curl-impersonate:0.5-chrome curl_chrome110 https://www.wikipedia.org
+docker run --rm lwthiker/curl-impersonate:0.5-chrome curl_chrome110 https://www.example.com
 ```
 
 ### Distro packages

--- a/docs/03_usage.md
+++ b/docs/03_usage.md
@@ -5,11 +5,11 @@ Since it is just a modified curl build, all the original flags and command-line 
 
 For example, it can be run as follows:
 
-    curl-impersonate -v -L https://wikipedia.org
+    curl-impersonate -v -L https://www.example.com
 
 However, by default, running the binaries as above will not produce the same TLS and HTTP/2 signatures as the impersonated browsers. Rather, this project provides additional *wrapper scripts* that launch these binaries with the correct set of command line flags to produce the desired signatures. For example:
 
-    curl_chrome104 -v -L https://wikipedia.org
+    curl_chrome104 -v -L https://www.example.com
 
 will produce a signature identical to Chrome version 104. You can add command line flags and they will be passed on to curl. However, some flags change curl's TLS signature. See below for more details.
 


### PR DESCRIPTION
Updated example URL in usage instructions. Use the domain names explicitly reserved by IANA and IETF for documentation rather than encouraging folks to test or attack Wikipedia. https://en.wikipedia.org/wiki/Example.net

Fix: https://github.com/lexiforest/curl-impersonate/issues/239